### PR TITLE
docs(ja): translate integrations/index into Japanese

### DIFF
--- a/docs/src/pages/ja/integrations.(index).mdx
+++ b/docs/src/pages/ja/integrations.(index).mdx
@@ -1,3 +1,11 @@
-import Page from "../en/integrations.(index).mdx";
+# 統合
 
-<Page />
+このセクションでは、`@lazarv/react-server`を様々なツールやサードパーティライブラリと統合する方法について紹介します。
+
+`@lazarv/react-server`は[Vite](/integrations/vite)をベースに構築されているため、Viteで利用可能な統合のほとんどがこのフレームワークでも利用できます。ViteとReact-Serverの両方で同じ設定を使用できるだけでなく、あらゆるViteプラグインをプロジェクトで使用することができます。また、既存のVite Reactプロジェクトをサーバーサイドレンダリング機能を使用するように[移行](/integrations/vite#migration)する方法についても学ぶことができます。
+
+`@lazarv/react-server`でTypeScriptやTailwind CSSを使用したい場合は、[TypeScript](/integrations/typescript)の設定方法や、[Tailwind CSS](/integrations/tailwind-css)のインストールと設定方法について学ぶことができます。
+
+また、このセクションでは[TanStack Query](/integrations/react-query)、[Mantine UI](/integrations/mantine)、[Material UI](/integrations/mui)などのサードパーティライブラリを`@lazarv/react-server`と統合する方法についても説明しています。
+
+> より多くのガイドが近日追加される予定ですので、後日再度ご確認ください。


### PR DESCRIPTION
This Pull Request to add Japanese documentation about integrations/index. This is a documentation-only change with no impact on functionality

https://react-server.dev/ja/integrations

### Status
@TKHShun 's review